### PR TITLE
Update course name in Notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ To read the contents of the IPython notebook, check the pdf file under 'extra'.
 
 To start studying this interactively:
  - go to https://notebooks.csc.fi
- - login with Haka account (*if you don't have a Haka account you need a special notebooks.csc.fi account created for you, contact notebooks@csc.fi*)
- - find the blueprint called "Course Introduction to R (self-study)", click on "Launch new"
+ - login with Haka or Virtu account (*if you don't have a Haka/Virtu account you need a special notebooks.csc.fi account created for you, contact notebooks@csc.fi*)
+ - find the application called "Introduction to R", click on "Launch new"
  - Wait for the "Open in browser" to appear under Access and click on it. This will open Jupyter in a new tab in your browser
  - In Jupyter click on __R-for-beginners__ and then on __baseRintro.ipynb__. This will start the notebook in another new tab in your browser
  - Follow the instructions in the notebook. Happy learning!


### PR DESCRIPTION
Updated the name of the course space and terminology to match that currently seen in Notebooks. Changed 'Haka' to 'Haka and Virtu'.