### PR TITLE
Update instructions and links

### DIFF
--- a/baseRintro.ipynb
+++ b/baseRintro.ipynb
@@ -64,7 +64,7 @@
     "\n",
     "## 1.2 Checkpoints in Jupyter\n",
     "\n",
-    "Jupyter notebooks are fully editable, which means that you can edit both the text and code fields. If you delete something and want to restore a previous version of the notebook, this can be done using *checkpoints*. You can easily create a checkpoint by using the button on the Jupyter tool bar or via the File menu. __Now would be a good time to create your first checkpoint.__ \n",
+    "Jupyter notebooks are fully editable, which means that you can edit both the text and code fields. If you delete something and want to restore a previous version of the notebook, this can be done using *checkpoints*. You can easily create a checkpoint by using the save button on the Jupyter tool bar or via the File menu. __Now would be a good time to create your first checkpoint.__ \n",
     "\n",
     "Accidentally closing the browser tab of the notebook is also not a problem. Just reopen it from the Jupyter home tab. If you've closed that too (or e.g. if you wish to switch browsers or computers) you can start over from [notebooks.csc.fi](https://notebooks.csc.fi). Your notebook can will remain intact for as long as the virtual machine session is running.\n",
     "\n",
@@ -72,11 +72,11 @@
     "\n",
     "To keep a copy of your work, you can download the notebook in several formats (via the File menu). The following formats may be useful:\n",
     "\n",
-    "- Notebook: use this in case you want to return to the actual complete notebook on another Jupyter instance. Notebooks on [notebooks.csc.fi](https://notebooks.csc.fi) only stay up for a limited time and if you want to work for longer than that, this is what you need. You can restart the R for Beginners machine and before clicking on the .ipynb file to open the notebook, upload and replace the notebook (the .ipynb file) with the version you downloaded earlier.\n",
+    "- Notebook (File -> Download): use this in case you want to return to the actual complete notebook on another Jupyter instance. Notebooks on [notebooks.csc.fi](https://notebooks.csc.fi) only stay up for a limited time and if you want to work for longer than that, this is what you need. You can restart the R for Beginners machine and before clicking on the .ipynb file to open the notebook, upload and replace the notebook (the .ipynb file) with the version you downloaded earlier.\n",
     "\n",
-    "- R code: this will download only the parts involving R code (e.g. for importing in RStudio).\n",
+    "- R code (File -> Save and Export Notebook as -> Executable Script): this will download only the parts involving R code (e.g. for importing in RStudio).\n",
     "\n",
-    "- PDF: this will create a PDF document which is possible to read but not work on. It's best to do this without the outputs (choose 'Restart & Clear Output' from the Kernel menu)."
+    "- PDF (File -> Save and Export Notebook as -> PDF): this will create a PDF document which is possible to read but not work on. It's best to do this without the outputs (choose 'Restart & Clear Output' from the Kernel menu)."
    ]
   },
   {
@@ -110,7 +110,7 @@
    "source": [
     "## 2.1 Creating objects\n",
     "\n",
-    "One of the key features of R is that your data can be assigned to a named *object* using the operator `<-` (less-than symbol followed by a dash). A quick way to type this is Alt + dash. Try running the code below, which assigns the result of a calculation to an object we have decided to call `answerA`:"
+    "One of the key features of R is that your data can be assigned to a named *object* using the operator `<-` (less-than symbol followed by a dash). Try running the code below, which assigns the result of a calculation to an object we have decided to call `answerA`:"
    ]
   },
   {
@@ -837,7 +837,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The summary shows us that there are five variables: four numeric ones and one factor with three levels (each with 50 observations). The `head(iris)` call is used to look at a few first lines of the data frame, instead of looking at all 150 of them. Next, we can look at the documentation page of this data set. This will open a new pop-up window in Jupyter. You can close it afterwards or you can move it to its own tab using the button in its top right corner."
+    "The summary shows us that there are five variables: four numeric ones and one factor with three levels (each with 50 observations). The `head(iris)` call is used to look at a few first lines of the data frame, instead of looking at all 150 of them. Next, we can look at the documentation page of this data set."
    ]
   },
   {
@@ -1030,7 +1030,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "getwd() # This will likely say: '/home/jovyan/work/R-for-beginners'"
+    "getwd() # This will likely say: '/home/jovyan/R-for-beginners'"
    ]
   },
   {
@@ -1307,7 +1307,7 @@
     "\n",
     "Of course, consider installing both R and RStudio on your own computer. Note that they are two different things: R is provided by CRAN and comes with its own (very basic) interface. RStudio is an alternative user interface provided by the RStudio company. The open-source version of RStudio can be downloaded for free.\n",
     "\n",
-    "Using RStudio efficiently is its own separate learning objective and is intertwined with learning how to use a collection of packages called __tidyverse__, also provided by the RStudio company. See the [tidyverse website](www.tidyverse.org) for more information and the book 'R for Data Science' linked there. These packages have an underlying philosophy that slightly differs from base R, so prepare to relearn a few things. Watch videos, read through tutorials, take a course online or offline. It'll be worth it. Good luck!"
+    "Using RStudio efficiently is its own separate learning objective and is intertwined with learning how to use a collection of packages called __tidyverse__, also provided by the RStudio company. See the [tidyverse website](http://www.tidyverse.org/) for more information and the book 'R for Data Science' linked there. These packages have an underlying philosophy that slightly differs from base R, so prepare to relearn a few things. Watch videos, read through tutorials, take a course online or offline. It'll be worth it. Good luck!"
    ]
   }
  ],


### PR DESCRIPTION
Updated wording of instructions for saving etc. to match how the Jupyter notebook currently looks and works. Removed information that is not correct anymore (iris documentation doesn't open in a pop up window, Alt+ dash doesn't seem to work here for <- , at least not on a Mac when the same works in RStudio?). Fixed tidyverse link.